### PR TITLE
development

### DIFF
--- a/interaction.go
+++ b/interaction.go
@@ -18,22 +18,18 @@ var (
 	ErrContextTooLarge = errors.New("context data exceeds discovery limit")
 )
 
-// LoginState gets the InteractionState of the login challenge.
 func (s *SDK) LoginState(ctx context.Context, xid string) (*InteractionState, error) {
 	return s.getInteractionState(ctx, s.discovery.LoginEndpoint, []string{oidc.ScopeTigaLogin}, xid)
 }
 
-// SelectAccountState gets the InteractionState of the select account challenge.
 func (s *SDK) SelectAccountState(ctx context.Context, xid string) (*InteractionState, error) {
 	return s.getInteractionState(ctx, s.discovery.SelectAccountEndpoint, []string{oidc.ScopeTigaSelectAccount}, xid)
 }
 
-// ConsentState gets the InteractionState of the consent challenge.
 func (s *SDK) ConsentState(ctx context.Context, xid string) (*InteractionState, error) {
 	return s.getInteractionState(ctx, s.discovery.ConsentEndpoint, []string{oidc.ScopeTigaConsent}, xid)
 }
 
-// LoginCallback posts the End-User's LoginCallback response back to Tiga.
 func (s *SDK) LoginCallback(ctx context.Context, xid string, callback *LoginCallback) (bool, error) {
 	if limit := s.discovery.InteractionContextDataKBLimit; limit > 0 && int64(len(callback.Context))/1024 > limit {
 		return false, ErrContextTooLarge
@@ -41,12 +37,10 @@ func (s *SDK) LoginCallback(ctx context.Context, xid string, callback *LoginCall
 	return s.interactionCallback(ctx, s.discovery.LoginEndpoint, []string{oidc.ScopeTigaLogin}, callback, xid)
 }
 
-// SelectAccountCallback posts the End-User's SelectAccountCallback response back to Tiga.
 func (s *SDK) SelectAccountCallback(ctx context.Context, xid string, callback *SelectAccountCallback) (bool, error) {
 	return s.interactionCallback(ctx, s.discovery.SelectAccountEndpoint, []string{oidc.ScopeTigaSelectAccount}, callback, xid)
 }
 
-// ConsentCallback posts the End-User's ConsentCallback response back to Tiga.
 func (s *SDK) ConsentCallback(ctx context.Context, xid string, callback *ConsentCallback) (bool, error) {
 	return s.interactionCallback(ctx, s.discovery.ConsentEndpoint, []string{oidc.ScopeTigaConsent}, callback, xid)
 }
@@ -120,7 +114,6 @@ func (s *SDK) getInteractionState(ctx context.Context, endpoint string, scopes [
 	}
 }
 
-// ResumeAuthorize redirects the http response back to the authorize resume endpoint.
 func (s *SDK) ResumeAuthorize(rw http.ResponseWriter, r *http.Request, xid string) {
 	u, _ := url.Parse(s.discovery.AuthorizeResumeEndpoint)
 	u.RawQuery = url.Values{"xid": []string{xid}}.Encode()

--- a/stub.go
+++ b/stub.go
@@ -1,0 +1,45 @@
+package tigasdk
+
+import (
+	"context"
+	"net/http"
+)
+
+// Stub describes the client side functions provided by the SDK to communicate
+// with the Tiga instance. It is included in the SDK so that client side code
+// can implement it to mock Tiga during development and testing.
+type Stub interface {
+	// TokenByClientCredentials acquire access tokens using the client_credentials flow.
+	TokenByClientCredentials(ctx context.Context, scopes []string) (*TokenResponse, error)
+
+	// TokenByCode acquire access tokens, and optionally refresh token and id_token using the authorization_code flow.
+	TokenByCode(ctx context.Context, code string, redirectURI string, scopes []string) (*TokenResponse, error)
+
+	// TokenByRefreshToken acquire access tokens and refresh token by exchanging in existing refresh token.
+	TokenByRefreshToken(ctx context.Context, refreshToken string, scopes []string) (*TokenResponse, error)
+
+	// LoginState gets the InteractionState of the login challenge.
+	LoginState(ctx context.Context, xid string) (*InteractionState, error)
+
+	// SelectAccountState gets the InteractionState of the select account challenge.
+	SelectAccountState(ctx context.Context, xid string) (*InteractionState, error)
+
+	// ConsentState gets the InteractionState of the consent challenge.
+	ConsentState(ctx context.Context, xid string) (*InteractionState, error)
+
+	// LoginCallback posts the End-User's LoginCallback response back to Tiga.
+	LoginCallback(ctx context.Context, xid string, callback *LoginCallback) (bool, error)
+
+	// SelectAccountCallback posts the End-User's SelectAccountCallback response back to Tiga.
+	SelectAccountCallback(ctx context.Context, xid string, callback *SelectAccountCallback) (bool, error)
+
+	// ConsentCallback posts the End-User's ConsentCallback response back to Tiga.
+	ConsentCallback(ctx context.Context, xid string, callback *ConsentCallback) (bool, error)
+
+	// ResumeAuthorize redirects the http response back to the authorize resume endpoint.
+	ResumeAuthorize(rw http.ResponseWriter, r *http.Request, xid string)
+}
+
+// Keep this type check as New does not
+// return Stub type.
+var _ Stub = (*SDK)(nil)

--- a/token.go
+++ b/token.go
@@ -20,7 +20,6 @@ var (
 	ErrUnexpectedResponse = errors.New("sdk received unexpected response")
 )
 
-// TokenByClientCredentials acquire access tokens using the client_credentials flow.
 func (s *SDK) TokenByClientCredentials(ctx context.Context, scopes []string) (*TokenResponse, error) {
 	options, err := s.createTokenRequest(map[string]string{
 		"client_id":  s.clientId,
@@ -34,7 +33,6 @@ func (s *SDK) TokenByClientCredentials(ctx context.Context, scopes []string) (*T
 	return s.executeTokenRequest(ctx, options)
 }
 
-// TokenByCode acquire access tokens, and optionally refresh token and id_token using the authorization_code flow.
 func (s *SDK) TokenByCode(ctx context.Context, code string, redirectURI string, scopes []string) (*TokenResponse, error) {
 	options, err := s.createTokenRequest(map[string]string{
 		"client_id":    s.clientId,
@@ -50,7 +48,6 @@ func (s *SDK) TokenByCode(ctx context.Context, code string, redirectURI string, 
 	return s.executeTokenRequest(ctx, options)
 }
 
-// TokenByRefreshToken acquire access tokens and refresh token by exchanging in existing refresh token.
 func (s *SDK) TokenByRefreshToken(ctx context.Context, refreshToken string, scopes []string) (*TokenResponse, error) {
 	options, err := s.createTokenRequest(map[string]string{
 		"client_id":     s.clientId,


### PR DESCRIPTION
- go mod init
- jwx package
- add key gen
- oidc package
- add discovery
- access token protection
- move out protect and tokens to sdk object
- interaction
- go mod tidy
- add validity functions to jwa
- add jwt claims, add iss claim
- implement json marshaling for jwt claims wrapper fix ExpectAud logic
- add Discovery
- fix jwks reading bug
- context data size limit
- fix bug to use 1024 instead of 1000 in kb/b conversion
- add pkce constants
- expose protect middleware to party with discovery and key set
- add README and github action
- add scope to token response
- use xid and nonce to replace challenge
- include the stub interface
